### PR TITLE
Update AWS Glue Data Catalog AWS CLI Command

### DIFF
--- a/dags/data_lake__01_clean_and_prep_demo.py
+++ b/dags/data_lake__01_clean_and_prep_demo.py
@@ -52,7 +52,7 @@ with DAG(
     create_demo_catalog = BashOperator(
         task_id="create_demo_catalog",
         bash_command="""aws glue create-database --database-input \
-            '{"Name": "tickit_demo", "Description": "Track sales activity for the fictional TICKIT web site"}'""",
+            '{"Name": "tickit_demo", "Description": "Datasets from AWS's E-commerce TICKIT relational database"}'""",
     )
 
 chain(


### PR DESCRIPTION
Update AWS Glue Data Catalog command in DAG: data_lake__01_clean_and_prep_demo.py.